### PR TITLE
bump for compatibility with 9.6.6

### DIFF
--- a/JuicyPixels-blurhash.cabal
+++ b/JuicyPixels-blurhash.cabal
@@ -51,7 +51,7 @@ library
     , bytestring >=0.11
     , containers >=0.4.2 && <0.7
     , filepath >=1.4.1.1 && <1.5
-    , vector >=0.10 && <0.13
+    , vector >=0.10 && <=0.14
   default-language: Haskell2010
 
 executable JuicyPixels-blurhash-exe

--- a/JuicyPixels-blurhash.cabal
+++ b/JuicyPixels-blurhash.cabal
@@ -48,7 +48,7 @@ library
   build-depends:
       JuicyPixels >=3.2.8 && <3.4
     , base >=4.7 && <5
-    , bytestring >=0.9 && <0.11
+    , bytestring >=0.11
     , containers >=0.4.2 && <0.7
     , filepath >=1.4.1.1 && <1.5
     , vector >=0.10 && <0.13
@@ -65,7 +65,7 @@ executable JuicyPixels-blurhash-exe
       JuicyPixels >=3.2.8 && <3.4
     , JuicyPixels-blurhash
     , base >=4.7 && <5
-    , bytestring >=0.9 && <0.11
+    , bytestring >=0.11
     , containers >=0.4.2 && <0.7
     , filepath >=1.4.1.1 && <1.5
     , optparse-applicative >=0.14.3 && <0.18
@@ -85,9 +85,9 @@ test-suite JuicyPixels-blurhash-doctests
     , JuicyPixels >=3.2.8 && <3.4
     , JuicyPixels-blurhash
     , base >=4.7 && <5
-    , bytestring >=0.9 && <0.11
+    , bytestring >=0.11
     , containers >=0.4.2 && <0.7
-    , doctest >=0.16.2 && <0.20
+    , doctest >=0.22
     , filepath >=1.4.1.1 && <1.5
     , vector >=0.10 && <0.13
   default-language: Haskell2010
@@ -102,14 +102,15 @@ test-suite JuicyPixels-blurhash-test
       JuicyPixels >=3.2.8 && <3.4
     , JuicyPixels-blurhash
     , base >=4.7 && <5
-    , bytestring >=0.9 && <0.11
+    , bytestring >=0.11
     , containers >=0.4.2 && <0.7
     , filepath >=1.4.1.1 && <1.5
-    , hedgehog >=1.0.2 && <1.2
+    , hedgehog >=1.4
     , tasty >=1.2.3 && <1.5
-    , tasty-discover >=4.2.1 && <4.3
-    , tasty-hedgehog >=1.0.0.2 && <1.2
+    , tasty-hedgehog >=1.4
     , tasty-hunit >=0.10.0.2 && <0.11
     , vector >=0.10 && <0.13
+  build-tool-depends:
+    tasty-discover:tasty-discover >=4.2 && <4.3
   default-language: Haskell2010
   other-modules: Blurhash

--- a/JuicyPixels-blurhash.cabal
+++ b/JuicyPixels-blurhash.cabal
@@ -49,8 +49,8 @@ library
       JuicyPixels >=3.2.8 && <3.4
     , base >=4.7 && <5
     , bytestring >=0.11
-    , containers >=0.4.2 && <0.7
-    , filepath >=1.4.1.1 && <1.5
+    , containers >=0.4.2 && <=0.7
+    , filepath >=1.4.1.1 && <=1.6
     , vector >=0.10 && <=0.14
   default-language: Haskell2010
 
@@ -66,10 +66,10 @@ executable JuicyPixels-blurhash-exe
     , JuicyPixels-blurhash
     , base >=4.7 && <5
     , bytestring >=0.11
-    , containers >=0.4.2 && <0.7
-    , filepath >=1.4.1.1 && <1.5
+    , containers >=0.4.2 && <=0.7
+    , filepath >=1.4.1.1 && <=1.6
     , optparse-applicative >=0.14.3 && <0.18
-    , vector >=0.10 && <0.13
+    , vector >=0.10 && <=0.14
   default-language: Haskell2010
 
 test-suite JuicyPixels-blurhash-doctests
@@ -86,10 +86,10 @@ test-suite JuicyPixels-blurhash-doctests
     , JuicyPixels-blurhash
     , base >=4.7 && <5
     , bytestring >=0.11
-    , containers >=0.4.2 && <0.7
+    , containers >=0.4.2 && <=0.7
     , doctest >=0.22
-    , filepath >=1.4.1.1 && <1.5
-    , vector >=0.10 && <0.13
+    , filepath >=1.4.1.1 && <=1.6
+    , vector >=0.10 && <=0.14
   default-language: Haskell2010
 
 test-suite JuicyPixels-blurhash-test
@@ -103,13 +103,13 @@ test-suite JuicyPixels-blurhash-test
     , JuicyPixels-blurhash
     , base >=4.7 && <5
     , bytestring >=0.11
-    , containers >=0.4.2 && <0.7
-    , filepath >=1.4.1.1 && <1.5
+    , containers >=0.4.2 && <=0.7
+    , filepath >=1.4.1.1 && <=1.6
     , hedgehog >=1.4
     , tasty >=1.2.3 && <1.5
     , tasty-hedgehog >=1.4
     , tasty-hunit >=0.10.0.2 && <0.11
-    , vector >=0.10 && <0.13
+    , vector >=0.10 && <=0.14
   build-tool-depends:
     tasty-discover:tasty-discover >=4.2 && <4.3
   default-language: Haskell2010

--- a/doctest/Main.hs
+++ b/doctest/Main.hs
@@ -4,4 +4,15 @@ import System.FilePath.Glob (glob)
 import Test.DocTest (doctest)
 
 main :: IO ()
-main = glob "src/**/*.hs" >>= doctest
+main = do
+  sources <- glob "src/**/*.hs"
+  doctest $
+    [ "-isrc"
+    , "-XTemplateHaskell"
+    , "-XCPP"
+    , "-package=JuicyPixels"
+    , "-package=bytestring"
+    , "-package=containers"
+    , "-package=vector"
+    , "-package=filepath"
+    ] ++ sources

--- a/package.yaml
+++ b/package.yaml
@@ -62,10 +62,10 @@ tests:
     - -with-rtsopts=-N
     dependencies:
     - JuicyPixels-blurhash
-    - hedgehog >= 1.0.2 && < 1.2
+    - hedgehog >= 1.4
     - tasty >= 1.2.3 && < 1.5
     - tasty-discover >= 4.2.1 && < 4.3
-    - tasty-hedgehog >= 1.0.0.2 && < 1.2
+    - tasty-hedgehog >=1.4
     - tasty-hunit >= 0.10.0.2 && < 0.11
   JuicyPixels-blurhash-doctests:
     main:                Main.hs

--- a/src/Codec/Picture/Blurhash/Internal/Base83.hs
+++ b/src/Codec/Picture/Blurhash/Internal/Base83.hs
@@ -17,7 +17,7 @@ import Data.Foldable (foldlM)
 import Data.Word (Word8)
 
 import qualified Data.ByteString.Lazy as BS
-import qualified Data.ByteString.Lazy.Builder as BS
+import qualified Data.ByteString.Builder as BS
 import qualified Data.Map as Map
 import qualified Data.Vector as V
 

--- a/src/Codec/Picture/Blurhash/Internal/DList.hs
+++ b/src/Codec/Picture/Blurhash/Internal/DList.hs
@@ -20,7 +20,7 @@ toDList l = \l' -> l ++ l'
 
 -- | Convert a difference list to a list
 dListToList :: DList a -> [a]
-dListToList = ($[])
+dListToList = ($ [])
 
 -- | Append an item to the end of a difference list
 dListSnoc :: DList a -> a -> DList a

--- a/src/Codec/Picture/Blurhash/Internal/Encode.hs
+++ b/src/Codec/Picture/Blurhash/Internal/Encode.hs
@@ -18,7 +18,7 @@ import Data.Foldable (foldl')
 import GHC.Generics (Generic)
 
 import qualified Data.ByteString.Lazy as BS
-import qualified Data.ByteString.Lazy.Builder as BS
+import qualified Data.ByteString.Builder as BS
 import Codec.Picture (DynamicImage, Image(..), PixelRGB8(..), PixelRGBF(..), convertRGB8, colorMap)
 import Codec.Picture.Types (pixelFold, ColorConvertible(..)) -- ColorConvertible imported for haddocks
 


### PR DESCRIPTION
- `Data.Bytestring.Lazy.Builder` is now just `Data.Bytestring.Builder`
- tasty-discover is properly marked as a build-tool-depends
- doctest version bump broke compatibility with cabal, so manually build `doctest/Main.hs` flags

I'm not very experienced Haskellian, so I apologize for any dumb mistakes here